### PR TITLE
fix: restructure CI workflows to match branch protection check names

### DIFF
--- a/.github/workflows/ci-shared.yml
+++ b/.github/workflows/ci-shared.yml
@@ -1,0 +1,12 @@
+name: CI Shared
+
+on:
+  workflow_call:
+
+jobs:
+  Lint:
+    uses: TytaniumDev/.github/.github/workflows/lint.yml@main
+  Build:
+    uses: TytaniumDev/.github/.github/workflows/build.yml@main
+  Test:
+    uses: TytaniumDev/.github/.github/workflows/test.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,5 @@ on:
     branches: [main]
 
 jobs:
-  CI-Lint:
-    uses: TytaniumDev/.github/.github/workflows/lint.yml@main
-  CI-Build:
-    uses: TytaniumDev/.github/.github/workflows/build.yml@main
-  CI-Test:
-    uses: TytaniumDev/.github/.github/workflows/test.yml@main
+  CI:
+    uses: ./.github/workflows/ci-shared.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,3 +61,4 @@ Tests stub WoW APIs and `LibStub` at the top of each file, then `dofile()` the s
 - Serialization for addon comms uses `:ToDict()` / `.FromDict()` pattern on model classes
 - Table append idiom: `t[#t + 1] = value` (not `table.insert`)
 - External libraries (Ace3, LibStub, etc.) are fetched at release time by BigWigsMods packager per `.pkgmeta` — the `libs/` dir is gitignored except `.gitkeep`
+- **CI job naming constraint:** `.github/workflows/ci-shared.yml` is a reusable workflow (`workflow_call` only) that defines three jobs: `Lint`, `Build`, `Test`. It is called by `.github/workflows/ci.yml` (trigger: `pull_request` only) via a calling job with ID `CI`. GitHub Actions names reusable workflow checks as `<calling_job_id> / <reusable_job_id>`, producing `CI / Lint`, `CI / Build`, `CI / Test` — which branch protection requires. Do not rename the calling job ID in `ci.yml` or the job IDs in `ci-shared.yml`, and do not add extra triggers to `ci.yml`.


### PR DESCRIPTION
## Summary
- Extract `ci-shared.yml` reusable workflow with job IDs `Lint`, `Build`, `Test`
- Update `ci.yml` to call `ci-shared.yml` via a single calling job with ID `CI`, producing check names `CI / Lint`, `CI / Build`, `CI / Test` that match branch protection requirements
- Add CI job naming constraint to CLAUDE.md to prevent recurrence

## Test plan
- [ ] Verify CI checks on this PR report as `CI / Lint`, `CI / Build`, `CI / Test`
- [ ] Confirm branch protection recognizes the checks as matching required status checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)