### PR TITLE
fix: run CI before deploy and fix wago packaging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ name: Deploy Addon
 on:
   push:
     tags: [v*]
-    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -22,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Auto-create version tag
-        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        if: github.event_name == 'workflow_dispatch'
         run: |
           DATE_PREFIX="v$(date -u +'%Y.%-m.%-d')"
           PATCH=0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  CI-Lint:
+    uses: TytaniumDev/.github/.github/workflows/lint.yml@main
+  CI-Build:
+    uses: TytaniumDev/.github/.github/workflows/build.yml@main
+  CI-Test:
+    uses: TytaniumDev/.github/.github/workflows/test.yml@main
+
+  deploy:
+    needs: [CI-Lint, CI-Build, CI-Test]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - run: gh workflow run deploy.yml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Reverts the `branches: [main]` trigger from deploy.yml — the BigWigsMods packager skips packaging when it finds a tag at HEAD during a branch push ("future tag" check), which is why wago.io wasn't updated
- Adds a new `release.yml` workflow that triggers on push to main: runs CI (lint, build, test) first, then triggers deploy.yml via `workflow_dispatch`
- The `workflow_dispatch` path already handles auto-tagging and the packager works correctly in that context

## Test plan
- [ ] Merge and verify the Release workflow triggers on push to main
- [ ] Verify CI jobs (lint, build, test) run before deploy
- [ ] Verify the deploy workflow is triggered via workflow_dispatch and packages successfully
- [ ] Confirm wago.io is updated with the new release

🤖 Generated with [Claude Code](https://claude.com/claude-code)