### PR TITLE
fix: remove double "v" prefix in version display and add release URL

### DIFF
--- a/src/Config.lua
+++ b/src/Config.lua
@@ -106,6 +106,7 @@ MPW.MAX_LEVEL = 90
 
 -- Addon version (replaced by packager with git tag)
 MPW.VERSION = "@project-version@"
+MPW.RELEASE_URL = "https://github.com/TytaniumDev/Wheelson/releases/tag/@project-version@"
 
 -- Session timeout in seconds (default 30 minutes)
 MPW.SESSION_TIMEOUT = 1800

--- a/src/Core.lua
+++ b/src/Core.lua
@@ -53,7 +53,7 @@ function MPW:OnInitialize()
         end,
         OnTooltipShow = function(tooltip)
             tooltip:AddLine("Mythic+ Wheel", 1, 0.82, 0)
-            tooltip:AddLine("|cFFAAAAAAv" .. MPW.VERSION .. "|r")
+            tooltip:AddLine("|cFFAAAAAA" .. MPW.VERSION .. "|r")
             if MPW.session.status then
                 tooltip:AddLine("Session: " .. MPW.session.status, 0.5, 1, 0.5)
                 tooltip:AddLine("Host: " .. (MPW.session.host or "Unknown"), 0.7, 0.7, 0.7)

--- a/src/UI/OptionsPanel.lua
+++ b/src/UI/OptionsPanel.lua
@@ -18,7 +18,7 @@ local function GetDiscoveryText()
     local lines = {}
     local cache = MPW.addonUsersCache or {}
     for _, entry in pairs(cache) do
-        lines[#lines + 1] = entry.name .. "  (v" .. entry.version .. ")"
+        lines[#lines + 1] = entry.name .. "  (" .. entry.version .. ")"
     end
 
     if #lines == 0 then
@@ -52,6 +52,26 @@ local options = {
             func = function()
                 MPW:SendAddonPing()
             end,
+        },
+        versionHeader = {
+            order = 10,
+            type = "header",
+            name = "Version",
+        },
+        versionDesc = {
+            order = 11,
+            type = "description",
+            name = MPW.VERSION,
+            fontSize = "medium",
+        },
+        releaseUrl = {
+            order = 12,
+            type = "input",
+            name = "Release Link",
+            desc = "Copy this URL to view the release on GitHub",
+            get = function() return MPW.RELEASE_URL end,
+            set = function() end,
+            width = "full",
         },
     },
 }


### PR DESCRIPTION
## Summary
- Fix double "v" prefix in version strings — packager's `@project-version@` already includes the "v" from the git tag, so display code no longer prepends another
- Add `MPW.RELEASE_URL` constant pointing to the GitHub release for the current version
- Add a Version section to the AddOns options panel with a copyable release URL field

## Test plan
- [x] All 112 tests pass
- [x] Lint clean
- [ ] Verify version shows as `v2026.x.x.x` (not `vv2026.x.x.x`) in minimap tooltip and options panel
- [ ] Verify release URL field in AddOns > Wheelson options panel is selectable/copyable

🤖 Generated with [Claude Code](https://claude.com/claude-code)