### PR TITLE
fix: hide all views before showing new view to prevent overlap

### DIFF
--- a/src/UI/GroupDisplay.lua
+++ b/src/UI/GroupDisplay.lua
@@ -177,6 +177,11 @@ local function RenderGroupCard(parent, index, group, yOffset)
     return cardHeight + 8
 end
 
+--- Hide the group display view.
+function WHLSN:HideGroupDisplayView()
+    if displayFrame then displayFrame:Hide() end
+end
+
 --- Show the group display view.
 function WHLSN:ShowGroupDisplayView(parent)
     if displayFrame then displayFrame:Hide() end

--- a/src/UI/Lobby.lua
+++ b/src/UI/Lobby.lua
@@ -241,6 +241,11 @@ local function CreateHistoryRow(parent, index)
     return row
 end
 
+--- Hide the lobby view.
+function WHLSN:HideLobbyView()
+    if lobbyFrame then lobbyFrame:Hide() end
+end
+
 --- Show the lobby view inside the given content frame.
 function WHLSN:ShowLobbyView(parent)
     if lobbyFrame then lobbyFrame:Hide() end

--- a/src/UI/MainFrame.lua
+++ b/src/UI/MainFrame.lua
@@ -140,6 +140,13 @@ function WHLSN:ShowMainFrame()
     self:UpdateUI()
 end
 
+--- Hide all view frames so only the next shown view is visible.
+function WHLSN:HideAllViews()
+    self:HideLobbyView()
+    self:HideWheelView()
+    self:HideGroupDisplayView()
+end
+
 --- Update the UI based on current session state.
 function WHLSN:UpdateUI()
     local frame = GetMainFrame()
@@ -150,18 +157,21 @@ function WHLSN:UpdateUI()
 
     if status == self.Status.LOBBY then
         if currentView ~= "lobby" then
+            self:HideAllViews()
             self:ShowLobbyView(frame.Content)
             currentView = "lobby"
         end
         self:UpdateLobbyView()
     elseif status == self.Status.SPINNING then
         if currentView ~= "wheel" then
+            self:HideAllViews()
             self:ShowWheelView(frame.Content)
             currentView = "wheel"
         end
         self:UpdateWheelView()
     elseif status == self.Status.COMPLETED then
         if currentView ~= "results" then
+            self:HideAllViews()
             self:ShowGroupDisplayView(frame.Content)
             currentView = "results"
         end
@@ -169,6 +179,7 @@ function WHLSN:UpdateUI()
     else
         -- No session: show idle/join state
         if currentView ~= "lobby" then
+            self:HideAllViews()
             self:ShowLobbyView(frame.Content)
             currentView = "lobby"
         end

--- a/src/UI/Wheel.lua
+++ b/src/UI/Wheel.lua
@@ -152,6 +152,15 @@ local function CreateGroupCard(parent, index, group)
     return card, texts
 end
 
+--- Hide the wheel view and cancel any pending animation timers.
+function WHLSN:HideWheelView()
+    if revealTimer then
+        revealTimer:Cancel()
+        revealTimer = nil
+    end
+    if wheelFrame then wheelFrame:Hide() end
+end
+
 --- Show the wheel view inside the given content frame.
 function WHLSN:ShowWheelView(parent)
     if wheelFrame then wheelFrame:Hide() end


### PR DESCRIPTION
## Summary
- Each `Show*View` function only hid its own previous frame, never the other views — causing all three views (lobby, wheel, results) to render simultaneously and stack on top of each other
- Added `Hide` methods to each view file (`HideLobbyView`, `HideWheelView`, `HideGroupDisplayView`) and a centralized `HideAllViews()` in MainFrame.lua
- `UpdateUI()` now calls `HideAllViews()` before showing any new view, ensuring only one page is visible at a time

## Test plan
- [ ] Start a test session, verify only the lobby view is visible
- [ ] Spin the wheel, verify the lobby disappears and only the wheel animation is visible
- [ ] After spin completes, verify only the results view is visible with no lobby/wheel elements bleeding through
- [ ] End session and verify clean return to lobby
- [ ] Luacheck and busted pass (verified locally: 0 warnings, 125/125 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)