### PR TITLE
fix: use forward slashes in TOC file paths for macOS compatibility

### DIFF
--- a/Wheelson.toc
+++ b/Wheelson.toc
@@ -4,44 +4,44 @@
 ## Author: MythicPlusDiscordBot Contributors
 ## Version: @project-version@
 ## SavedVariables: WheelsonDB
-## IconTexture: Interface\AddOns\Wheelson\textures\minimap-icon
+## IconTexture: Interface/AddOns/Wheelson/textures/minimap-icon
 ## X-Curse-Project-ID: 1484744
 ## X-Wago-ID: kGryLYKy
 
 # Embedded Libraries
-libs\LibStub\LibStub.lua
-libs\CallbackHandler-1.0\CallbackHandler-1.0.lua
-libs\AceAddon-3.0\AceAddon-3.0.lua
-libs\AceConsole-3.0\AceConsole-3.0.lua
-libs\AceEvent-3.0\AceEvent-3.0.lua
-libs\AceComm-3.0\AceComm-3.0.lua
-libs\AceSerializer-3.0\AceSerializer-3.0.lua
-libs\AceDB-3.0\AceDB-3.0.lua
-libs\AceConfig-3.0\AceConfig-3.0.xml
-libs\AceGUI-3.0\AceGUI-3.0.lua
-libs\LibDataBroker-1.1\LibDataBroker-1.1.lua
-libs\LibDBIcon-1.0\LibDBIcon-1.0.lua
+libs/LibStub/LibStub.lua
+libs/CallbackHandler-1.0/CallbackHandler-1.0.lua
+libs/AceAddon-3.0/AceAddon-3.0.lua
+libs/AceConsole-3.0/AceConsole-3.0.lua
+libs/AceEvent-3.0/AceEvent-3.0.lua
+libs/AceComm-3.0/AceComm-3.0.lua
+libs/AceSerializer-3.0/AceSerializer-3.0.lua
+libs/AceDB-3.0/AceDB-3.0.lua
+libs/AceConfig-3.0/AceConfig-3.0.xml
+libs/AceGUI-3.0/AceGUI-3.0.lua
+libs/LibDataBroker-1.1/LibDataBroker-1.1.lua
+libs/LibDBIcon-1.0/LibDBIcon-1.0.lua
 
 # Core
-src\Config.lua
-src\Models.lua
-src\TestData.lua
-src\GroupCreator.lua
-src\Core.lua
+src/Config.lua
+src/Models.lua
+src/TestData.lua
+src/GroupCreator.lua
+src/Core.lua
 
 # Services
-src\Services\SpecService.lua
-src\Services\GuildService.lua
-src\Services\PartyService.lua
+src/Services/SpecService.lua
+src/Services/GuildService.lua
+src/Services/PartyService.lua
 
 # Utilities
-src\Utils\Helpers.lua
+src/Utils/Helpers.lua
 
 # UI
-src\UI\MainFrame.xml
-src\UI\MainFrame.lua
-src\UI\Lobby.lua
-src\UI\Wheel.lua
-src\UI\GroupDisplay.lua
-src\UI\DebugPanel.lua
-src\UI\OptionsPanel.lua
+src/UI/MainFrame.xml
+src/UI/MainFrame.lua
+src/UI/Lobby.lua
+src/UI/Wheel.lua
+src/UI/GroupDisplay.lua
+src/UI/DebugPanel.lua
+src/UI/OptionsPanel.lua

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,7 +9,7 @@ fi
 
 echo "=== Checking all .toc source files exist ==="
 # Skip libs/ entries — libraries are gitignored and fetched at release time by BigWigsMods packager
-grep -E '^[^#].*\.(lua|xml)$' Wheelson.toc | grep -v '^libs\\' | tr '\\' '/' | while IFS= read -r file; do
+grep -E '^[^#].*\.(lua|xml)$' Wheelson.toc | grep -v '^libs/' | while IFS= read -r file; do
   if [ ! -f "$file" ]; then
     echo "ERROR: $file listed in .toc but not found on disk" >&2
     exit 1


### PR DESCRIPTION
## Summary
- Replace backslash (`\`) path separators with forward slashes (`/`) in `Wheelson.toc` so the addon loads on both macOS and Windows WoW clients
- Update `scripts/build.sh` to match the new forward-slash paths in its libs filter

## Context
The addon silently failed to load on macOS because the WoW Mac client doesn't translate backslashes in TOC file paths. It worked on Windows because `\` is the native path separator there, and having ElvUI installed provided Ace3 libraries independently.

## Test plan
- [x] `luacheck src/ tests/` passes
- [x] `busted` — 133 tests pass
- [x] `bash scripts/build.sh` — build validation passes
- [ ] Verify addon loads on macOS WoW client

🤖 Generated with [Claude Code](https://claude.com/claude-code)