### PR TITLE
fix: wheel sound stacking, reel speed, and player pool

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -34,6 +34,7 @@ read_globals = {
     "GetNumGroupMembers",
     "GetNumGuildMembers",
     "GetNumSpecializations",
+    "GetTime",
     "hooksecurefunc",
     "IsInGuild",
     "IsInGroup",

--- a/src/UI/Wheel.lua
+++ b/src/UI/Wheel.lua
@@ -89,13 +89,19 @@ end
 -- SOUND_VICTORY : WoW 12.0 UI Alert – Slot Machine Coins (jackpot payout)
 ---------------------------------------------------------------------------
 
-local SOUND_TICK    = 271528  -- GamblingSlotMachine03_Tri_Face_Vertical_Spin
-local SOUND_LAND    = 272764  -- GamblingSlotMachine06_Wheel_Face_Spin_End
-local SOUND_VICTORY = 316718  -- 12.0_UI_Alert_Devices_Slot_Machine_Coins
-local SOUND_START   = 271526  -- Foley_Goblin_Casino_Slot_Machine_Arm_Crank_Start
+local SOUND_TICK    = 856     -- igMainMenuOptionCheckboxOn (ultra-short click)
+local SOUND_LAND    = 316717  -- 12.0_UI_Alert_Devices_Slot_Machine_Bell (short slot bell)
+local SOUND_VICTORY = 316769  -- 12.0_UI_Alert_War3_Fanfare (big fanfare)
+local SOUND_START   = 271526  -- Foley_Goblin_Casino_Slot_Machine_Arm_Crank_Start (keep)
+
+local TICK_THROTTLE = 0.15    -- seconds; at most one tick sound per 150ms across all reels
+local lastTickTime  = 0
 
 local function PlayTick()
     if not ShouldPlaySounds() then return end
+    local now = GetTime()
+    if now - lastTickTime < TICK_THROTTLE then return end
+    lastTickTime = now
     PlaySound(SOUND_TICK, "SFX")
 end
 

--- a/tests/test_wheel.lua
+++ b/tests/test_wheel.lua
@@ -49,6 +49,7 @@ _G.CreateColor = function(r, g, b, a) return { r = r, g = g, b = b, a = a } end
 
 _G.SOUNDKIT = {}
 _G.PlaySound = function() end
+_G.GetTime = function() return 0 end
 _G.C_Timer = {
     NewTimer = function(_, cb) return { Cancel = function() end } end,
     After = function(_, cb) end,


### PR DESCRIPTION
## Summary
- **Sound stacking**: Replace long Goblin Casino SoundKit IDs with shorter alternatives (856 tick, 316717 bell, 316769 fanfare) and add a global 150ms tick throttle so at most one tick plays across all 5 reels
- **Reverse-spin illusion**: DPS reels no longer spin faster than tank/healer reels — `CalcScrollMetrics` now targets a uniform 500 px/s linear-phase speed across all reels by calculating `numCycles` per reel
- **Player disappearing from reels**: `PrepareReelNames` now rotates the list to place the winner at index 1 instead of removing all duplicate copies, preserving every eligible player in the reel

## Test plan
- [ ] Start a session with mixed roles (tanks, healers, DPS) and spin
- [ ] Verify all 5 reels scroll at visually similar speeds — no wagon-wheel effect on DPS reels
- [ ] Verify sounds are subtle ticks during spin, short bell on each reel land, big fanfare at the end
- [ ] Verify no overwhelming sound stacking when all reels spin simultaneously
- [ ] With multiple groups, verify all eligible players still appear in every reel across all group spins
- [ ] Verify small pools (e.g., 2 tanks) still show both players in the reel, not just the winner

🤖 Generated with [Claude Code](https://claude.com/claude-code)