### PR TITLE
fix: prefer non-healer offtanks to avoid depleting healer pool

### DIFF
--- a/src/GroupCreator.lua
+++ b/src/GroupCreator.lua
@@ -128,11 +128,23 @@ function WHLSN:CreateMythicPlusGroups(players, guildId)
 
     local availableTanks = {}
     for _, p in ipairs(mainTanks) do availableTanks[#availableTanks + 1] = p end
-    for _, p in ipairs(offTanks) do availableTanks[#availableTanks + 1] = p end
+    -- Prefer offTanks who are NOT main healers to avoid depleting the healer pool
+    for _, p in ipairs(offTanks) do
+        if not p:IsHealerMain() then availableTanks[#availableTanks + 1] = p end
+    end
+    for _, p in ipairs(offTanks) do
+        if p:IsHealerMain() then availableTanks[#availableTanks + 1] = p end
+    end
 
     local availableHealers = {}
     for _, p in ipairs(mainHealers) do availableHealers[#availableHealers + 1] = p end
-    for _, p in ipairs(offHealers) do availableHealers[#availableHealers + 1] = p end
+    -- Prefer offHealers who are NOT main tanks to avoid depleting the tank pool
+    for _, p in ipairs(offHealers) do
+        if not p:IsTankMain() then availableHealers[#availableHealers + 1] = p end
+    end
+    for _, p in ipairs(offHealers) do
+        if p:IsTankMain() then availableHealers[#availableHealers + 1] = p end
+    end
 
     local availableDps = {}
     for _, p in ipairs(mainDps) do availableDps[#availableDps + 1] = p end

--- a/tests/test_group_creator.lua
+++ b/tests/test_group_creator.lua
@@ -28,6 +28,7 @@ dofile("src/Models.lua")
 dofile("src/GroupCreator.lua")
 
 local Player = Wheelson.Player
+local Group = Wheelson.Group
 local WHLSN = Wheelson
 
 ---------------------------------------------------------------------------
@@ -562,6 +563,65 @@ describe("CreateMythicPlusGroups", function()
             if g.healer then healerCount = healerCount + 1 end
         end
         assert.is_true(healerCount >= 1)
+    end)
+
+    it("should form 3 full groups from 15 players with healer-offtank (issue #40)", function()
+        local players = {
+            Player:New("Temma", "tank", {"melee"}, {"brez"}),
+            Player:New("Gazzi", "tank", {}, {"brez"}),
+            Player:New("Quill", "healer", {"tank", "ranged", "melee"}, {"brez"}),
+            Player:New("Sorovar", "healer", {}, {}),
+            Player:New("Vanyali", "ranged", {}, {}),
+            Player:New("Tytaniormu", "ranged", {}, {"lust"}),
+            Player:New("Heretofore", "ranged", {}, {"lust"}),
+            Player:New("Poppybrosjr", "ranged", {}, {"lust"}),
+            Player:New("Volkareth", "ranged", {"healer"}, {"lust"}),
+            Player:New("Johng", "melee", {}, {"brez"}),
+            Player:New("jim", "melee", {"tank"}, {}),
+            Player:New("Raxef", "melee", {}, {}),
+            Player:New("Mickey", "melee", {}, {}),
+            Player:New("Khurri", "melee", {}, {"brez"}),
+            Player:New("Blueshift", "ranged", {}, {"lust"}),
+        }
+        local lastGroups = {
+            Group:New(
+                Player:New("Gazzi", "tank", {}, {"brez"}),
+                Player:New("Sorovar", "healer", {}, {}),
+                {
+                    Player:New("Poppybrosjr", "ranged", {}, {"lust"}),
+                    Player:New("Johng", "melee", {}, {"brez"}),
+                    Player:New("Heretofore", "ranged", {}, {"lust"}),
+                }
+            ),
+            Group:New(
+                Player:New("Temma", "tank", {"melee"}, {"brez"}),
+                Player:New("Volkareth", "ranged", {"healer"}, {"lust"}),
+                {
+                    Player:New("Tytaniormu", "ranged", {}, {"lust"}),
+                    Player:New("Mickey", "melee", {}, {}),
+                    Player:New("Raxef", "melee", {}, {}),
+                }
+            ),
+            Group:New(
+                Player:New("jim", "melee", {"tank"}, {}),
+                Player:New("Quill", "healer", {"tank", "ranged", "melee"}, {"brez"}),
+                {
+                    Player:New("Blueshift", "ranged", {}, {"lust"}),
+                    Player:New("Khurri", "melee", {}, {"brez"}),
+                    Player:New("Vanyali", "ranged", {}, {}),
+                }
+            ),
+        }
+        WHLSN:SetLastGroups(lastGroups)
+        for _ = 1, 20 do
+            local groups = WHLSN:CreateMythicPlusGroups(players)
+            assert.equal(3, #groups, "Expected 3 groups from 15 players, got " .. #groups)
+            local totalPlayers = 0
+            for _, g in ipairs(groups) do
+                totalPlayers = totalPlayers + g:GetSize()
+            end
+            assert.equal(15, totalPlayers, "All 15 players should be assigned")
+        end
     end)
 
     it("should try to get ranged DPS in each group", function()


### PR DESCRIPTION
Closes #40

## Summary
- When building the available tank pool, offTanks who are also main healers are now placed last so the algorithm only uses a healer as a tank when no other offTanks are available
- Symmetric fix applied to the healer pool (offHealers who are main tanks placed last)
- Added regression test from the issue's reproduction case (runs 20 trials to account for shuffle randomness)

## Root Cause
With 15 players (2 main tanks, 2 offTanks including a main healer), the algorithm could randomly pick the main healer (Quill) as the 3rd tank instead of a non-healer offTank (jim). This depleted the healer pool, leaving one group without a healer (4 players), and the remaining player spilled into a 4th group.

## Test plan
- [x] New test reproduces the exact player/lastGroups data from issue #40
- [x] Test runs 20 trials to cover shuffle variations
- [x] All 152 tests pass
- [x] Lint clean, build valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)