### PR TITLE
fix: halve reel scroll speed, shorten duration, and remove landing snap

### DIFF
--- a/src/UI/Wheel.lua
+++ b/src/UI/Wheel.lua
@@ -208,21 +208,6 @@ end
 -- Easing Functions
 ---------------------------------------------------------------------------
 
---- Damped spring oscillation function used for Phase 4 (landing bounce).
---- Returns a value that starts at 1 and oscillates around 1 with decaying
---- amplitude, simulating a physical spring settling.
---- f(t) = 1 + e^(-k*t) * sin(w*t) * 0.04,  k=12, w=8
---- Clamped to return exactly 1 for t<=0 or t>=1.
----@param t number  normalised time [0, 1]
----@return number
-function WHLSN.DampedSpring(t)
-    if t <= 0 or t >= 1 then return 1 end
-    local k = 12
-    local w = 8
-    local amplitude = 0.04
-    return 1 + math.exp(-k * t) * math.sin(w * t) * amplitude
-end
-
 --- Three-phase slot-machine easing curve.
 ---
 ---  Phase 1 (0   → P1_END=0.0375): quartic ease-in,      maps scroll to  0% –  3%
@@ -706,7 +691,9 @@ OnUpdateHandler = function(_, dt)
                 state.landed = true
 
                 if reel and reel.slots then
-                    -- Winner is at slot j=3 (centre row, under pointer).
+                    -- At t=1: SlotEasing(1)=1, so scrollOffset=totalScroll and baseSlot=numNames-1.
+                    -- For j=3: nameIdx = ((numNames-1 + 1) % numNames)+1 = 1 = winner ✓
+                    -- No repositioning needed — animation loop already placed slots correctly.
                     for j = 1, 15 do
                         if j == 3 then
                             reel.slots[j]:SetTextColor(GOLD_R, GOLD_G, GOLD_B, 1)

--- a/tests/test_wheel.lua
+++ b/tests/test_wheel.lua
@@ -290,35 +290,6 @@ describe("SlotEasing", function()
 end)
 
 -- ---------------------------------------------------------------------------
--- DampedSpring tests
--- ---------------------------------------------------------------------------
-
-describe("DampedSpring", function()
-    it("should return 1 at t=0", function()
-        -- DampedSpring(0): envelope = e^0 = 1, sin(0)=0 → 1 + 0 = 1
-        assert.near(1, WHLSN.DampedSpring(0), 1e-9)
-    end)
-
-    it("should overshoot past 1 briefly", function()
-        -- With 1 + e^(-k*t)*sin(w*t)*0.04, the first half-lobe of sin is positive → overshoots above 1
-        local found_overshoot = false
-        local t = 0.01
-        while t <= 0.5 do
-            if WHLSN.DampedSpring(t) > 1.0 then
-                found_overshoot = true
-                break
-            end
-            t = t + 0.01
-        end
-        assert.is_true(found_overshoot)
-    end)
-
-    it("should settle near 1 at t=1", function()
-        assert.near(1, WHLSN.DampedSpring(1), 0.01)
-    end)
-end)
-
--- ---------------------------------------------------------------------------
 -- PrepareReelNames tests
 -- ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Halved `TARGET_SPEED` (500 → 250 px/s) so WoW can render the reel text cleanly
- Shortened `BASE_REEL_DURATIONS` (8-10.4s → 5-6.2s) so the animation doesn't feel too long
- Removed Phase 4 (DampedSpring bounce) entirely — the easeOutCubic deceleration now runs smoothly to t=1 with no oscillation, eliminating the visible snap at landing
- Removed hard snap repositioning at landing — only gold highlighting is applied since the animation loop already positions slots correctly at t=1
- Lowered `MIN_SPIN_CYCLES` (3 → 2) to maintain consistent scroll speed across different pool sizes

## Test plan
- [x] All 160 tests pass
- [x] Lint clean (0 warnings, 0 errors)
- [ ] Visual test: reel scroll speed is comfortable and readable
- [ ] Visual test: reel decelerates smoothly and settles on winner without any snap/jump
- [ ] Visual test: total animation duration feels appropriate (~5-6s per reel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)