### PR TITLE
fix: tune reel animation speed, easing, and visual polish

### DIFF
--- a/src/UI/Wheel.lua
+++ b/src/UI/Wheel.lua
@@ -56,6 +56,9 @@ local P2_END = 0.45     -- end of full speed
 local P1_OUT_END = 0.01
 local P2_OUT_END = 0.60
 
+-- Expose easing constants for testing
+WHLSN._EASING = { P1_END = P1_END, P2_END = P2_END, P1_OUT_END = P1_OUT_END, P2_OUT_END = P2_OUT_END }
+
 ---------------------------------------------------------------------------
 -- Animation State Variables
 ---------------------------------------------------------------------------
@@ -250,7 +253,7 @@ function WHLSN.SlotEasing(t)
         local a = v - 2
         local b = 3 - 2 * v
         local c = v
-        local eased = a * p * p * p + b * p * p + c * p
+        local eased = p * (c + p * (b + a * p))
         return P2_OUT_END + eased * P3_RANGE
     end
 end

--- a/tests/test_wheel.lua
+++ b/tests/test_wheel.lua
@@ -259,7 +259,7 @@ describe("SlotEasing", function()
 
     it("should accelerate quickly in phase 1", function()
         -- At 50% through phase 1, progress should be > 0 (quartic: grows fast)
-        local midP1 = 0.03 * 0.5
+        local midP1 = WHLSN._EASING.P1_END * 0.5
         local val = WHLSN.SlotEasing(midP1)
         assert.is_true(val > 0)
     end)
@@ -277,15 +277,16 @@ describe("SlotEasing", function()
     end)
 
     it("should be continuous at phase boundaries", function()
-        -- Phase 1 → Phase 2 boundary (t ≈ 0.03)
+        local E = WHLSN._EASING
         local eps = 1e-5
-        local before1 = WHLSN.SlotEasing(0.03 - eps)
-        local after1  = WHLSN.SlotEasing(0.03 + eps)
+        -- Phase 1 → Phase 2 boundary
+        local before1 = WHLSN.SlotEasing(E.P1_END - eps)
+        local after1  = WHLSN.SlotEasing(E.P1_END + eps)
         assert.near(before1, after1, 0.01)
 
-        -- Phase 2 → Phase 3 boundary (t ≈ 0.45)
-        local before2 = WHLSN.SlotEasing(0.45 - eps)
-        local after2  = WHLSN.SlotEasing(0.45 + eps)
+        -- Phase 2 → Phase 3 boundary
+        local before2 = WHLSN.SlotEasing(E.P2_END - eps)
+        local after2  = WHLSN.SlotEasing(E.P2_END + eps)
         assert.near(before2, after2, 0.01)
     end)
 end)
@@ -353,8 +354,9 @@ describe("CalcScrollMetrics", function()
         local _, _, _, largeTotal = WHLSN._CalcScrollMetrics(largeState)
 
         -- Linear phase speed = linearScrollFrac * totalScroll / (linearTimeFrac * duration)
-        local linearScrollFrac = 0.59  -- P2_OUT_END - P1_OUT_END
-        local linearTimeFrac   = 0.42  -- P2_END - P1_END
+        local E = WHLSN._EASING
+        local linearScrollFrac = E.P2_OUT_END - E.P1_OUT_END
+        local linearTimeFrac   = E.P2_END - E.P1_END
         local smallSpeed = linearScrollFrac * smallTotal / (linearTimeFrac * smallState.duration)
         local largeSpeed = linearScrollFrac * largeTotal / (linearTimeFrac * largeState.duration)
 


### PR DESCRIPTION
## Summary

- Halve reel scroll speed (TARGET_SPEED 250→50 px/s) and reduce minimum spin cycles (2→1) for a slower, more readable reveal animation
- Replace easeOutCubic deceleration with velocity-matched Hermite blend for smoother landing without jarring speed transitions
- Shorten base reel duration (5000ms→3000ms) and adjust easing phase boundaries for better feel
- Remove gold centre pointer line from reel frames (visual cleanup)
- Extract reel duration constants (`BASE_REEL_DURATION`, `REEL_DURATION_OFFSET`) for clarity

## Test plan

- [x] Unit tests updated and passing for new easing constants and scroll metric calculations
- [ ] In-game visual verification: reel animation feels slower, smoother, and lands cleanly
- [ ] Verify no visual artifacts from removed pointer line

🤖 Generated with [Claude Code](https://claude.com/claude-code)