### PR TITLE
fix: replace [BL]/[BR] text tags with spell icons in group display

### DIFF
--- a/src/UI/GroupDisplay.lua
+++ b/src/UI/GroupDisplay.lua
@@ -96,8 +96,8 @@ local function CreatePlayerLine(card, prefix, color, player, lineY)
     text:SetPoint("LEFT")
     if player then
         local utilStr = ""
-        if player:HasBrez() then utilStr = utilStr .. " |cFF00FF00[BR]|r" end
-        if player:HasLust() then utilStr = utilStr .. " |cFFFF4400[BL]|r" end
+        if player:HasBrez() then utilStr = utilStr .. " |TInterface\\Icons\\Spell_Nature_Reincarnation:0|t" end
+        if player:HasLust() then utilStr = utilStr .. " |TInterface\\Icons\\Spell_Nature_Bloodlust:0|t" end
         text:SetText(color .. prefix .. "|r  " .. player.name .. utilStr)
     else
         text:SetText("|cFF666666" .. prefix .. " (empty)|r")


### PR DESCRIPTION
## Summary
- Replace `[BL]` and `[BR]` colored text tags in the Group Display view with inline WoW spell icons (`Spell_Nature_Bloodlust` and `Spell_Nature_Reincarnation`)
- Matches the icon-based approach already used in the Lobby and Wheel views for visual consistency

## Test plan
- [ ] Open Wheelson, run a session, and verify Bloodlust/Battle Res icons appear inline next to player names in the group results view
- [ ] Confirm icons scale to match font height (`:0` size parameter)
- [ ] Verify tooltips still show "Battle Rez" and "Bloodlust/Heroism" text on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)