### PR TITLE
fix: simplify group display buttons for one-shot session flow

### DIFF
--- a/src/UI/GroupDisplay.lua
+++ b/src/UI/GroupDisplay.lua
@@ -77,8 +77,8 @@ local function CreateGroupDisplayFrame(parent)
     frame.endButton:SetPoint("BOTTOMRIGHT", -8, 8)
     frame.endButton:SetText("Finish")
     frame.endButton:SetScript("OnClick", function()
-        WHLSN:EndSession()
         WHLSN:ToggleMainFrame()
+        WHLSN:EndSession()
     end)
 
     return frame


### PR DESCRIPTION
## Summary
- Remove "New Session" button — sessions are one-shot (open, spin, invite, close)
- Rename "End Session" to "Finish" and close the addon frame when clicked
- Make "Invite My Group" button larger (130x30) with `GameFontNormalLarge` as the primary action

## Test plan
- [ ] Open addon, spin wheels, verify "Finish" button appears (no "New Session" or "End Session")
- [ ] Click "Finish" — session ends and frame closes
- [ ] Verify "Invite My Group" button is visually larger/more prominent
- [ ] View past session history — verify "Close" button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)