### PR TITLE
feat: use WoW class colors for player names

### DIFF
--- a/src/Models.lua
+++ b/src/Models.lua
@@ -10,6 +10,7 @@ local WHLSN = _G.Wheelson
 ---@field mainRole string|nil  "tank"|"healer"|"ranged"|"melee"
 ---@field offspecs string[]
 ---@field utilities string[]
+---@field classToken string|nil  WoW class token (e.g. "WARRIOR", "PRIEST")
 local Player = {}
 Player.__index = Player
 WHLSN.Player = Player
@@ -19,13 +20,15 @@ WHLSN.Player = Player
 ---@param mainRole string|nil
 ---@param offspecs? string[]
 ---@param utilities? string[]
+---@param classToken? string
 ---@return WHLSNPlayer
-function Player:New(name, mainRole, offspecs, utilities)
+function Player:New(name, mainRole, offspecs, utilities, classToken)
     local p = setmetatable({}, self)
     p.name = name
     p.mainRole = mainRole
     p.offspecs = offspecs or {}
     p.utilities = utilities or {}
+    p.classToken = classToken
     return p
 end
 
@@ -90,6 +93,7 @@ function Player:ToDict()
         mainRole = self.mainRole,
         offspecs = self.offspecs,
         utilities = self.utilities,
+        classToken = self.classToken,
     }
 end
 
@@ -101,7 +105,8 @@ function Player.FromDict(data)
         data.name,
         data.mainRole,
         data.offspecs or {},
-        data.utilities or {}
+        data.utilities or {},
+        data.classToken
     )
 end
 

--- a/src/Services/SpecService.lua
+++ b/src/Services/SpecService.lua
@@ -83,7 +83,7 @@ function WHLSN:DetectLocalPlayer(selectedOffspecs, overrideRole)
         utilities[#utilities + 1] = "lust"
     end
 
-    return WHLSN.Player:New(name, mainRole, offspecs, utilities)
+    return WHLSN.Player:New(name, mainRole, offspecs, utilities, classToken)
 end
 
 --- Strip realm name from a character name.
@@ -113,5 +113,5 @@ function WHLSN:DetectGuildMember(name, classToken)
         utilities[#utilities + 1] = "lust"
     end
 
-    return WHLSN.Player:New(name, nil, {}, utilities)
+    return WHLSN.Player:New(name, nil, {}, utilities, classToken)
 end

--- a/src/UI/GroupDisplay.lua
+++ b/src/UI/GroupDisplay.lua
@@ -157,7 +157,9 @@ end
 
 local function UpdatePlayerLine(lineFrame, prefix, hexColor, player)
     if player then
-        lineFrame.text:SetText("|cFF" .. hexColor .. prefix .. "|r  " .. player.name)
+        local cc = player.classToken and WHLSN.CLASS_COLORS[player.classToken]
+        local nameColor = cc and cc.hex or "FFFFFF"
+        lineFrame.text:SetText("|cFF" .. hexColor .. prefix .. "|r  |cFF" .. nameColor .. player.name .. "|r")
         lineFrame:SetScript("OnEnter", function(self)
             WHLSN:ShowPlayerTooltip(self, player)
         end)
@@ -180,8 +182,8 @@ local function UpdateUtilityRow(row, players)
     else
         local parts = {}
         for _, p in ipairs(players) do
-            local rc = WHLSN.RoleColors[p.mainRole]
-            local c = rc and rc.hex or DEFAULT_ROLE_COLOR
+            local cc = p.classToken and WHLSN.CLASS_COLORS[p.classToken]
+            local c = cc and cc.hex or DEFAULT_ROLE_COLOR
             parts[#parts + 1] = "|cFF" .. c .. p.name .. "|r"
         end
         row.names:SetText(table.concat(parts, "\n"))

--- a/src/UI/Lobby.lua
+++ b/src/UI/Lobby.lua
@@ -536,11 +536,14 @@ local function PopulatePlayerRows(frame, players)
             local tc = ROLE_TEXCOORDS[role]
             row.roleIcon:SetTexCoord(tc[1], tc[2], tc[3], tc[4])
             row.roleIcon:Show()
-
-            local rc = WHLSN.RoleColors[role]
-            row.nameText:SetTextColor(rc.r, rc.g, rc.b)
         else
             row.roleIcon:Hide()
+        end
+
+        local cc = player.classToken and WHLSN.CLASS_COLORS[player.classToken]
+        if cc then
+            row.nameText:SetTextColor(cc.r, cc.g, cc.b)
+        else
             row.nameText:SetTextColor(1, 1, 1)
         end
 

--- a/src/UI/Wheel.lua
+++ b/src/UI/Wheel.lua
@@ -872,21 +872,21 @@ local function AddSummaryRow(groupIndex)
     local group  = groups[groupIndex]
 
     local parts = {}
-    local function addColored(player, colorR, colorG, colorB)
+    local function addColored(player)
         if player then
-            parts[#parts + 1] = "|cff"
-                .. string.format("%02x%02x%02x",
-                    math_floor(colorR * 255),
-                    math_floor(colorG * 255),
-                    math_floor(colorB * 255))
-                .. player.name .. "|r"
+            local cc = player.classToken and WHLSN.CLASS_COLORS[player.classToken]
+            if cc then
+                parts[#parts + 1] = "|cFF" .. cc.hex .. player.name .. "|r"
+            else
+                parts[#parts + 1] = player.name
+            end
         end
     end
 
-    addColored(group.tank,   REEL_ROLES[1].color.r, REEL_ROLES[1].color.g, REEL_ROLES[1].color.b)
-    addColored(group.healer, REEL_ROLES[2].color.r, REEL_ROLES[2].color.g, REEL_ROLES[2].color.b)
+    addColored(group.tank)
+    addColored(group.healer)
     for k = 1, 3 do
-        addColored(group.dps[k], REEL_ROLES[3].color.r, REEL_ROLES[3].color.g, REEL_ROLES[3].color.b)
+        addColored(group.dps[k])
     end
 
     local summaryText = table.concat(parts, " · ")

--- a/src/Utils/Helpers.lua
+++ b/src/Utils/Helpers.lua
@@ -52,12 +52,12 @@ function WHLSN:FormatGroupSummary(groups)
     return table.concat(lines, "\n")
 end
 
---- Get a role-colored name string for display.
+--- Get a class-colored name string for display.
 ---@param player WHLSNPlayer
 ---@return string
 function WHLSN:ColoredPlayerName(player)
-    local rc = self.RoleColors[player.mainRole]
-    local color = rc and rc.hex or "FFFFFF"
+    local cc = player.classToken and self.CLASS_COLORS[player.classToken]
+    local color = cc and cc.hex or "FFFFFF"
     return "|cFF" .. color .. player.name .. "|r"
 end
 
@@ -103,7 +103,12 @@ end
 ---@param player WHLSNPlayer  player data
 function WHLSN:ShowPlayerTooltip(owner, player)
     GameTooltip:SetOwner(owner, "ANCHOR_RIGHT")
-    GameTooltip:AddLine(player.name, 1, 1, 1)
+    local cc = player.classToken and self.CLASS_COLORS[player.classToken]
+    if cc then
+        GameTooltip:AddLine(player.name, cc.r, cc.g, cc.b)
+    else
+        GameTooltip:AddLine(player.name, 1, 1, 1)
+    end
 
     local role = player.mainRole
     if role then


### PR DESCRIPTION
## Summary
- Added `classToken` field to `Player` model, serialized through addon comms (`ToDict`/`FromDict`)
- `SpecService` now passes the WoW class token when creating players (both local and guild members)
- All UI surfaces (lobby, group display cards, wheel summary rows, tooltips) color player names by WoW class instead of role
- Role colors retained for role label prefixes (TANK/HEAL/DPS) in group cards for role identification

## Test plan
- [x] 217 tests passing, 0 lint warnings
- [ ] Verify lobby player names show class colors in-game
- [ ] Verify group display cards show class-colored names with role-colored prefixes
- [ ] Verify wheel summary rows between group spins use class colors
- [ ] Verify tooltips show class-colored player name
- [ ] Verify players without classToken (edge case) fall back to white

🤖 Generated with [Claude Code](https://claude.com/claude-code)