### PR TITLE
fix: allow apostrophes in realm names for community roster (#67)

### DIFF
--- a/src/Services/CommunityService.lua
+++ b/src/Services/CommunityService.lua
@@ -16,7 +16,7 @@ function WHLSN:ValidateCommunityName(name)
     local trimmed = strtrim(name)
     if trimmed == "" then return false, "Name cannot be empty" end
     -- Validate format: Name or Name-Realm (realm may contain digits, e.g., Area52)
-    if not trimmed:match("^[%a']+$") and not trimmed:match("^[%a']+%-[%a%d%-]+$") then
+    if not trimmed:match("^[%a']+$") and not trimmed:match("^[%a']+%-[%a%d'%-]+$") then
         return false, "Invalid name format. Use 'Player' or 'Player-Realm'."
     end
     return true

--- a/tests/test_community_service.lua
+++ b/tests/test_community_service.lua
@@ -115,6 +115,11 @@ describe("CommunityService", function()
             assert.is_true(ok)
         end)
 
+        it("should accept realm names with apostrophes", function()
+            local ok = WHLSN:ValidateCommunityName("Tyler-Kel'Thuzad")
+            assert.is_true(ok)
+        end)
+
         it("should treat first hyphen as realm separator", function()
             -- "My-Name-Realm" → character "My" on realm "Name-Realm"
             local ok = WHLSN:ValidateCommunityName("My-NameRealm")


### PR DESCRIPTION
## Summary
- Fixes `ValidateCommunityName` rejecting `Name-Realm` entries for realms containing apostrophes (e.g. Kel'Thuzad, Cho'gall, Sen'jin)
- Updated the realm character class in the validation pattern from `[%a%d%-]` to `[%a%d'%-]`
- Adds a test case covering apostrophe realm names

## Root Cause
`GetNormalizedRealmName()` preserves apostrophes (only strips spaces), so autocomplete selection and manual entry of `Name-Kel'Thuzad` both failed validation silently — the apostrophe wasn't in the allowed character set for the realm portion of the pattern.

## Test Plan
- [x] `busted tests/test_community_service.lua` — 27 tests pass
- [x] Full suite `busted` — 227 tests pass
- [ ] In-game: verify adding a player on an apostrophe realm (e.g. Kel'Thuzad) via autocomplete and manual entry both succeed

Closes #67