### PR TITLE
fix: formalize busted and luacheck installation

### DIFF
--- a/scripts/install-luarocks-dep.sh
+++ b/scripts/install-luarocks-dep.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Helper script to install luarocks dependencies idempotently and OS-aware.
+# Usage: ./scripts/install-luarocks-dep.sh <package_name>
+
+PACKAGE_NAME=$1
+
+if [ -z "$PACKAGE_NAME" ]; then
+  echo "ERROR: Package name required." >&2
+  exit 1
+fi
+
+# Check if package is already in PATH
+if ! command -v "$PACKAGE_NAME" &> /dev/null; then
+  echo "=== Installing $PACKAGE_NAME ==="
+  if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    sudo apt-get update -qq && sudo apt-get install -y -qq luarocks >/dev/null
+    sudo luarocks install "$PACKAGE_NAME" >/dev/null
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    if ! command -v luarocks &> /dev/null; then
+      echo "=== Installing luarocks via brew ==="
+      brew install --quiet luarocks
+    fi
+    echo "=== Installing $PACKAGE_NAME via luarocks ==="
+    luarocks install "$PACKAGE_NAME"
+  else
+    echo "ERROR: Unsupported OS for automatic installation. Please install '$PACKAGE_NAME' manually." >&2
+    exit 1
+  fi
+fi

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,23 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Check if luacheck is already in PATH
-if ! command -v luacheck &> /dev/null; then
-  echo "=== Installing luacheck ==="
-  if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    sudo apt-get update -qq && sudo apt-get install -y -qq luarocks >/dev/null
-    sudo luarocks install luacheck >/dev/null
-  elif [[ "$OSTYPE" == "darwin"* ]]; then
-    if ! command -v luarocks &> /dev/null; then
-      echo "=== Installing luarocks via brew ==="
-      brew install luarocks
-    fi
-    echo "=== Installing luacheck via luarocks ==="
-    luarocks install luacheck
-  else
-    echo "ERROR: Unsupported OS for automatic installation. Please install 'luacheck' manually." >&2
-    exit 1
-  fi
+# Ensure luacheck is installed
+"$(dirname "$0")/install-luarocks-dep.sh" luacheck
+
+# Ensure local luarocks bin is in PATH if luarocks is available
+if command -v luarocks &> /dev/null; then
+  eval "$(luarocks path --bin)"
 fi
 
 echo "=== Running luacheck ==="

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,23 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Check if busted is already in PATH
-if ! command -v busted &> /dev/null; then
-  echo "=== Installing busted ==="
-  if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    sudo apt-get update -qq && sudo apt-get install -y -qq luarocks >/dev/null
-    sudo luarocks install busted >/dev/null
-  elif [[ "$OSTYPE" == "darwin"* ]]; then
-    if ! command -v luarocks &> /dev/null; then
-      echo "=== Installing luarocks via brew ==="
-      brew install luarocks
-    fi
-    echo "=== Installing busted via luarocks ==="
-    luarocks install busted
-  else
-    echo "ERROR: Unsupported OS for automatic installation. Please install 'busted' manually." >&2
-    exit 1
-  fi
+# Ensure busted is installed
+"$(dirname "$0")/install-luarocks-dep.sh" busted
+
+# Ensure local luarocks bin is in PATH if luarocks is available
+if command -v luarocks &> /dev/null; then
+  eval "$(luarocks path --bin)"
 fi
 
 echo "=== Running busted tests ==="


### PR DESCRIPTION
This PR updates the test and lint scripts to check for existing installations before attempting to install dependencies.

Key changes:
- Added OS detection (Linux vs. macOS) to === Running busted tests ===
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
227 successes / 0 failures / 0 errors / 0 pending : 0.045849 seconds and === Running luacheck ===
Checking src/Config.lua                           [0m[32m[1mOK[0m
Checking src/Core.lua                             [0m[32m[1mOK[0m
Checking src/GroupCreator.lua                     [0m[32m[1mOK[0m
Checking src/Models.lua                           [0m[32m[1mOK[0m
Checking src/Services/CommunityService.lua        [0m[32m[1mOK[0m
Checking src/Services/GuildService.lua            [0m[32m[1mOK[0m
Checking src/Services/PartyService.lua            [0m[32m[1mOK[0m
Checking src/Services/SpecService.lua             [0m[32m[1mOK[0m
Checking src/TestData.lua                         [0m[32m[1mOK[0m
Checking src/UI/DebugPanel.lua                    [0m[32m[1mOK[0m
Checking src/UI/GroupDisplay.lua                  [0m[32m[1mOK[0m
Checking src/UI/Lobby.lua                         [0m[32m[1mOK[0m
Checking src/UI/MainFrame.lua                     [0m[32m[1mOK[0m
Checking src/UI/OptionsPanel.lua                  [0m[32m[1mOK[0m
Checking src/UI/Wheel.lua                         [0m[32m[1mOK[0m
Checking src/Utils/Helpers.lua                    [0m[32m[1mOK[0m
Checking tests/test_community_service.lua         [0m[32m[1mOK[0m
Checking tests/test_core.lua                      [0m[32m[1mOK[0m
Checking tests/test_group_creator.lua             [0m[32m[1mOK[0m
Checking tests/test_guild_service.lua             [0m[32m[1mOK[0m
Checking tests/test_helpers.lua                   [0m[32m[1mOK[0m
Checking tests/test_models.lua                    [0m[32m[1mOK[0m
Checking tests/test_spec_service.lua              [0m[32m[1mOK[0m
Checking tests/test_test_mode.lua                 [0m[32m[1mOK[0m
Checking tests/test_wheel.lua                     [0m[32m[1mOK[0m

Total: [0m[0m[1m0[0m warnings / [0m[0m[1m0[0m errors in 25 files.
- Scripts now check if +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
227 successes / 0 failures / 0 errors / 0 pending : 0.045489 seconds or  are already in the .
- On macOS, installation avoids  where possible as the user owns the rocks directory.
- Fixed 
Usage: luarocks [-h] [--version] [--dev] [--server <server>]
       [--only-server <server>] [--only-sources <url>]
       [--namespace <namespace>] [--lua-dir <prefix>]
       [--lua-version <ver>] [--tree <tree>] [--local] [--global]
       [--no-project] [--force-lock] [--verbose] [--timeout <seconds>]
       [<command>] ...

LuaRocks 3.13.0, the Lua package manager

/opt/homebrew/bin/luarocks - LuaRocks main command-line interface

Options:
   -h, --help            Show this help message and exit.
   --version             Show version info and exit.
   --dev                 Enable the sub-repositories in rocks servers for
                         rockspecs of in-development versions.
   --server <server>     Fetch rocks/rockspecs from this server (takes priority
                         over config file).
   --only-server <server>
                         Fetch rocks/rockspecs from this server only (overrides
                         any entries in the config file).
   --only-sources <url>  Restrict downloads to paths matching the given URL.
   --namespace <namespace>
                         Specify the rocks server namespace to use.
   --lua-dir <prefix>    Which Lua installation to use.
   --lua-version <ver>   Which Lua version to use.
   --tree <tree>         Which tree to operate on.
   --local               Use the tree in the user's home directory.
                         To enable it, see '/opt/homebrew/bin/luarocks help
                         path'.
   --global              Use the system tree when `local_by_default` is `true`.
   --no-project          Do not use project tree even if running from a project
                         folder.
   --force-lock          Attempt to overwrite the lock for commands that require
                         exclusive access, such as 'install'
   --verbose             Display verbose output of commands executed.
   --timeout <seconds>   Timeout on network operations, in seconds.
                         0 means no timeout (wait forever). Default is 30.

Commands:
   help                  Show help for commands.
   completion            Output a shell completion script.
   build                 Build/compile a rock.
   config                Query information about the LuaRocks configuration.
   doc                   Show documentation for an installed rock.
   download              Download a specific rock file from a rocks server.
   init                  Initialize a directory for a Lua project using
                         LuaRocks.
   install               Install a rock.
   lint                  Check syntax of a rockspec.
   list                  List currently installed rocks.
   make                  Compile package in current directory using a rockspec.
   new_version           Auto-write a rockspec for a new version of a rock.
   pack                  Create a rock, packing sources or binaries.
   path                  Return the currently configured package path.
   purge                 Remove all installed rocks from a tree.
   remove                Uninstall a rock.
   search                Query the LuaRocks servers.
   show                  Show information about an installed rock.
   test                  Run the test suite in the current directory.
   unpack                Unpack the contents of a rock.
   upload                Upload a rockspec to the public rocks repository.
   which                 Tell which file corresponds to a given module name.
   write_rockspec        Write a template for a rockspec file.

Variables:
   Variables from the "variables" table of the configuration file can be
   overridden with VAR=VALUE assignments.

Configuration:
   Lua:
      Version    : 5.5
      LUA        : /opt/homebrew/opt/lua/bin/lua5.5 (ok)
      LUA_INCDIR : /opt/homebrew/opt/lua/include/lua5.5 (ok)
      LUA_LIBDIR : /opt/homebrew/opt/lua/lib (ok)

   Configuration files:
      System  : /opt/homebrew/etc/luarocks/config-5.5.lua (ok)
      User    : /Users/tylerholland/.luarocks/config-5.5.lua (not found)

   Rocks trees in use:
      /Users/tylerholland/.luarocks ("user")
      /opt/homebrew ("system") flags (removed invalid ).

This avoids the repetitive password prompts reported by users.

This PR was prepared by an AI assistant.