### PR TITLE
fix: replace invalid BATTLEGROUND_EXITED event with PVP_MATCH_COMPLETE

### DIFF
--- a/src/Core.lua
+++ b/src/Core.lua
@@ -100,7 +100,7 @@ function WHLSN:OnEnable()
     self:RegisterEvent("ENCOUNTER_END")
     self:RegisterEvent("CHALLENGE_MODE_COMPLETED")
     self:RegisterEvent("CHALLENGE_MODE_RESET")
-    self:RegisterEvent("BATTLEGROUND_EXITED")
+    self:RegisterEvent("PVP_MATCH_COMPLETE")
 end
 
 function WHLSN:OnDisable()
@@ -466,7 +466,7 @@ end
 function WHLSN:ENCOUNTER_END()        flushAfterDelay() end
 function WHLSN:CHALLENGE_MODE_COMPLETED() flushAfterDelay() end
 function WHLSN:CHALLENGE_MODE_RESET()     flushAfterDelay() end
-function WHLSN:BATTLEGROUND_EXITED()      flushAfterDelay() end
+function WHLSN:PVP_MATCH_COMPLETE()       flushAfterDelay() end
 
 --- Broadcast session state to the guild (throttled).
 function WHLSN:BroadcastSessionUpdate()


### PR DESCRIPTION
## Problem

The addon fails to load with:

```
AceEvent30Frame:RegisterEvent(): Attempt to register unknown event "BATTLEGROUND_EXITED"
```

`BATTLEGROUND_EXITED` is not a valid WoW event.

## Fix

Replace with `PVP_MATCH_COMPLETE`, which:
- Was added in patch 8.2.0 and remains valid in 12.0 (Midnight)
- Fires when a PvP match ends
- Correctly signals when the comm restriction from `C_PvP.IsActiveBattlefield()` has lifted, allowing queued addon messages to be flushed

## Changes

- `src/Core.lua`: Updated event registration and handler from `BATTLEGROUND_EXITED` to `PVP_MATCH_COMPLETE`

## Testing

All 234 tests pass with 0 failures.