### PR TITLE
feat: integrate Wago Analytics

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -26,6 +26,9 @@ externals:
     url: https://repos.curseforge.com/wow/ace3/trunk/CallbackHandler-1.0
   libs/LibDataBroker-1.1:
     url: https://github.com/tekkub/libdatabroker-1-1
+  libs/WagoAnalytics:
+    url: https://github.com/wagoio/WagoAnalyticsShim.git
+    branch: main
 
 ignore:
   - tests

--- a/Wheelson.toc
+++ b/Wheelson.toc
@@ -7,6 +7,7 @@
 ## IconTexture: Interface/AddOns/Wheelson/textures/minimap-icon
 ## X-Curse-Project-ID: 1484744
 ## X-Wago-ID: kGryLYKy
+## OptionalDependencies: WagoAnalytics
 
 # Embedded Libraries
 # Lua files listed explicitly to avoid upstream Ace3 XML backslash path issues on macOS.
@@ -52,6 +53,7 @@ libs/AceConfig-3.0/AceConfigDialog-3.0/AceConfigDialog-3.0.lua
 libs/AceConfig-3.0/AceConfig-3.0.lua
 libs/LibDataBroker-1.1/LibDataBroker-1.1.lua
 libs/LibDBIcon-1.0/LibDBIcon-1.0.lua
+libs/WagoAnalytics/Shim.lua
 
 # Core
 src/Config.lua

--- a/src/Config.lua
+++ b/src/Config.lua
@@ -4,6 +4,9 @@ local WHLSN = LibStub("AceAddon-3.0"):NewAddon(
 )
 _G.Wheelson = WHLSN
 
+-- Wago Analytics (Shim guarantees WagoAnalytics is never nil)
+WHLSN.analytics = LibStub("WagoAnalytics"):Register("kGryLYKy")
+
 -- Addon communication prefix (max 16 chars)
 WHLSN.COMM_PREFIX = "WHLSN"
 

--- a/src/Core.lua
+++ b/src/Core.lua
@@ -144,6 +144,9 @@ function WHLSN:StartSession()
     self.session.algorithmSnapshot = nil
     self.session.connectedCommunity = {}
     self.session.removedPlayers = {}
+    -- Wago Analytics
+    self.analytics:IncrementCounter("sessionsStarted")
+
     -- Auto-add the host as the first player
     local hostPlayer = self:DetectLocalPlayer()
     if hostPlayer then
@@ -265,6 +268,11 @@ function WHLSN:SpinGroups()
 
     self.session.groups = self:CreateMythicPlusGroups(activePlayers)
     self.session.status = self.Status.SPINNING
+
+    -- Wago Analytics
+    self.analytics:IncrementCounter("spins")
+    self.analytics:IncrementCounter("groupsFormed", #self.session.groups)
+    self.analytics:IncrementCounter("totalPlayersInLobbies", #activePlayers)
 
     -- Capture algorithm outputs
     local groupDicts = {}

--- a/tests/test_community_service.lua
+++ b/tests/test_community_service.lua
@@ -30,6 +30,9 @@ _G.LibStub = function(name, silent)
         return { NewDataObject = function(_, _name, obj) return obj end }
     elseif name == "LibDBIcon-1.0" then
         return { Register = function() end, Show = function() end, Hide = function() end }
+    elseif name == "WagoAnalytics" then
+        local noop = setmetatable({}, { __index = function() return function() end end })
+        return { Register = function(_, _id) return noop end }
     end
     if silent then return nil end
     return {}

--- a/tests/test_core.lua
+++ b/tests/test_core.lua
@@ -44,6 +44,9 @@ _G.LibStub = function(name, silent)
             Show = function() end,
             Hide = function() end,
         }
+    elseif name == "WagoAnalytics" then
+        local noop = setmetatable({}, { __index = function() return function() end end })
+        return { Register = function(_, _id) return noop end }
     end
     if silent then return nil end
     return {}

--- a/tests/test_group_creator.lua
+++ b/tests/test_group_creator.lua
@@ -19,6 +19,7 @@ _G.LibStub = function()
         return addon
     end
     addon.New = function(_, name, defaults) return { profile = defaults and defaults.profile or {} } end
+    addon.Register = function(_, _id) return setmetatable({}, { __index = function() return function() end end }) end
     return addon
 end
 

--- a/tests/test_guild_service.lua
+++ b/tests/test_guild_service.lua
@@ -16,6 +16,7 @@ _G.LibStub = function()
         return addon
     end
     addon.New = function(_, name, defaults) return { profile = defaults and defaults.profile or {} } end
+    addon.Register = function(_, _id) return setmetatable({}, { __index = function() return function() end end }) end
     return addon
 end
 

--- a/tests/test_helpers.lua
+++ b/tests/test_helpers.lua
@@ -16,6 +16,7 @@ _G.LibStub = function()
         return addon
     end
     addon.New = function(_, name, defaults) return { profile = defaults and defaults.profile or {} } end
+    addon.Register = function(_, _id) return setmetatable({}, { __index = function() return function() end end }) end
     return addon
 end
 

--- a/tests/test_models.lua
+++ b/tests/test_models.lua
@@ -16,6 +16,7 @@ _G.LibStub = function()
         return addon
     end
     addon.New = function(_, name, defaults) return { profile = defaults and defaults.profile or {} } end
+    addon.Register = function(_, _id) return setmetatable({}, { __index = function() return function() end end }) end
     return addon
 end
 

--- a/tests/test_party_service.lua
+++ b/tests/test_party_service.lua
@@ -30,6 +30,9 @@ _G.LibStub = function(name, silent)
         return { NewDataObject = function(_, _name, obj) return obj end }
     elseif name == "LibDBIcon-1.0" then
         return { Register = function() end, Show = function() end, Hide = function() end }
+    elseif name == "WagoAnalytics" then
+        local noop = setmetatable({}, { __index = function() return function() end end })
+        return { Register = function(_, _id) return noop end }
     end
     if silent then return nil end
     return {}

--- a/tests/test_spec_service.lua
+++ b/tests/test_spec_service.lua
@@ -16,6 +16,7 @@ _G.LibStub = function()
         return addon
     end
     addon.New = function(_, name, defaults) return { profile = defaults and defaults.profile or {} } end
+    addon.Register = function(_, _id) return setmetatable({}, { __index = function() return function() end end }) end
     return addon
 end
 

--- a/tests/test_test_mode.lua
+++ b/tests/test_test_mode.lua
@@ -42,6 +42,9 @@ _G.LibStub = function(name, silent)
         return {
             Register = function() end,
         }
+    elseif name == "WagoAnalytics" then
+        local noop = setmetatable({}, { __index = function() return function() end end })
+        return { Register = function(_, _id) return noop end }
     end
     if silent then return nil end
     return {}

--- a/tests/test_wheel.lua
+++ b/tests/test_wheel.lua
@@ -37,6 +37,9 @@ _G.LibStub = function(name, silent)
             RegisterOptionsTable = function() end,
             NotifyChange = function() end,
         }
+    elseif name == "WagoAnalytics" then
+        local noop = setmetatable({}, { __index = function() return function() end end })
+        return { Register = function(_, _id) return noop end }
     end
     if silent then return nil end
     return {}


### PR DESCRIPTION
## Summary
- Add WagoAnalytics shim as BigWigs packager external dependency
- Register addon with Wago Analytics on load (using shim per official docs — no nil guards)
- Track usage counters: `sessionsStarted`, `spins`, `groupsFormed`, `totalPlayersInLobbies`
- Add `WagoAnalytics` as optional dependency in `.toc`
- Stub WagoAnalytics in all test files

## Test plan
- [x] `busted` — all 268 tests pass
- [ ] Verify counters appear in Wago Analytics dashboard after a release build session

🤖 Generated with [Claude Code](https://claude.com/claude-code)