### PR TITLE
fix: cross-realm guild members not receiving party invites

### DIFF
--- a/src/Core.lua
+++ b/src/Core.lua
@@ -723,11 +723,7 @@ function WHLSN:HandleJoinRequest(data, sender, distribution)
     end
 
     local player = WHLSN.Player.FromDict(data.player)
-
-    -- Preserve realm-qualified name from sender for cross-realm invites
-    if sender:find("-") then
-        player.name = sender
-    end
+    self:ResolvePlayerName(player, sender)
 
     -- Replace if already in list
     for i, p in ipairs(self.session.players) do
@@ -781,11 +777,7 @@ function WHLSN:HandleSpecUpdate(data, sender, distribution)
     end
 
     local player = WHLSN.Player.FromDict(data.player)
-
-    -- Preserve realm-qualified name from sender for cross-realm invites
-    if sender:find("-") then
-        player.name = sender
-    end
+    self:ResolvePlayerName(player, sender)
 
     -- Find and replace existing player
     for i, p in ipairs(self.session.players) do

--- a/src/Services/SpecService.lua
+++ b/src/Services/SpecService.lua
@@ -104,6 +104,15 @@ function WHLSN:StripRealmName(name)
     return cached
 end
 
+--- Resolve a player's name using the comm sender, preserving realm for cross-realm players.
+---@param player WHLSNPlayer
+---@param sender string The addon comm sender (may include "-RealmName")
+function WHLSN:ResolvePlayerName(player, sender)
+    if sender:find("-") then
+        player.name = sender
+    end
+end
+
 --- Detect a guild member's likely role from guild roster info.
 --- Less accurate than DetectLocalPlayer since we can't see their spec directly.
 ---@param name string

--- a/tests/test_party_service.lua
+++ b/tests/test_party_service.lua
@@ -252,3 +252,40 @@ describe("HandleJoinRequest cross-realm", function()
         assert.equals("ranged", WHLSN.session.players[2].mainRole)
     end)
 end)
+
+describe("HandleSpecUpdate cross-realm", function()
+    before_each(function()
+        WHLSN:OnInitialize()
+        WHLSN.session.status = WHLSN.Status.LOBBY
+        WHLSN.session.host = "TestPlayer"
+        WHLSN.session.connectedCommunity = {}
+        WHLSN.Print = function() end
+        WHLSN.BroadcastSessionUpdate = function() end
+        WHLSN.IsCommunityRosterMember = function() return false end
+
+        -- Pre-populate a cross-realm player (as HandleJoinRequest would)
+        WHLSN.session.players = {
+            WHLSN.Player:New("TestPlayer", "tank"),
+            WHLSN.Player:New("CrossRealmPlayer-Stormrage", "healer", {}, {}, "PRIEST"),
+        }
+    end)
+
+    it("should preserve realm-qualified name on spec update", function()
+        local data = {
+            type = "SPEC_UPDATE",
+            player = {
+                name = "CrossRealmPlayer",
+                mainRole = "ranged",
+                offspecs = {},
+                utilities = { "lust" },
+                classToken = "MAGE",
+            },
+        }
+
+        WHLSN:HandleSpecUpdate(data, "CrossRealmPlayer-Stormrage", "GUILD")
+
+        assert.equals(2, #WHLSN.session.players)
+        assert.equals("CrossRealmPlayer-Stormrage", WHLSN.session.players[2].name)
+        assert.equals("ranged", WHLSN.session.players[2].mainRole)
+    end)
+end)


### PR DESCRIPTION
## Summary
- Preserve realm-qualified sender name on Player objects in `HandleJoinRequest` and `HandleSpecUpdate` so `C_PartyInfo.InviteUnit` receives `"Name-Realm"` for cross-realm guild members
- Previously, `DetectLocalPlayer` stripped realm info via `UnitName("player")`, and cross-realm guild members (GUILD channel) were never added to `connectedCommunity`, so invites fell back to bare names which WoW can't resolve cross-realm

## Test plan
- [x] New test: cross-realm guild member join preserves realm-qualified name
- [x] New test: same-realm guild member join keeps bare name
- [x] New test: re-join updates name correctly
- [x] New test: `InvitePlayers` uses realm-qualified name
- [x] All 273 existing tests pass
- [x] Lint clean, build validation passes
- [ ] Manual: open Wheelson, have a cross-realm guild member join and verify they receive the party invite

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)