### PR TITLE
ci: auto-merge Jules PRs when approved by Claude

### DIFF
--- a/.github/workflows/automerge-label.yml
+++ b/.github/workflows/automerge-label.yml
@@ -11,5 +11,10 @@ permissions:
 
 jobs:
   add-label:
-    if: github.event.review.state == 'approved' && github.event.review.user.login == 'TytaniumDev'
+    if: >-
+      github.event.review.state == 'approved' &&
+      (
+        github.event.review.user.login == 'TytaniumDev' ||
+        (github.event.review.user.login == 'claude' && github.event.pull_request.user.login == 'app/google-labs-jules')
+      )
     uses: TytaniumDev/.github/.github/workflows/automerge-label.yml@main


### PR DESCRIPTION
## Summary
- Extends `automerge-label.yml` to also add the automerge label when `claude` approves a PR authored by `app/google-labs-jules`
- Previously, only `TytaniumDev` approvals triggered the automerge label — requiring manual approval on every Jules PR
- `TytaniumDev` approvals still trigger automerge on any PR (existing behavior unchanged)

## Test plan
- [ ] Verify workflow lint passes on PR
- [ ] Next Jules PR that Claude approves should get the automerge label automatically
- [ ] Confirm TytaniumDev approvals still work as before on non-Jules PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)