### PR TITLE
fix: use correct bot login suffixes in automerge-label workflow

### DIFF
--- a/.github/workflows/automerge-label.yml
+++ b/.github/workflows/automerge-label.yml
@@ -15,6 +15,6 @@ jobs:
       github.event.review.state == 'approved' &&
       (
         github.event.review.user.login == 'TytaniumDev' ||
-        (github.event.review.user.login == 'claude' && github.event.pull_request.user.login == 'app/google-labs-jules')
+        (github.event.review.user.login == 'claude[bot]' && github.event.pull_request.user.login == 'google-labs-jules[bot]')
       )
     uses: TytaniumDev/.github/.github/workflows/automerge-label.yml@main


### PR DESCRIPTION
## Summary
- Bot accounts in GitHub Actions events use `claude[bot]` and `google-labs-jules[bot]` suffixes, not the short names shown in `gh` CLI output
- The `if` condition from #108 was never matching because it compared against `claude` and `app/google-labs-jules`
- This is why all 5 Claude-approved Jules PRs (#110, #111, #113, #114, #115) didn't get the automerge label

## Test plan
- [ ] Workflow lint passes
- [ ] Re-request Claude review on an open Jules PR to trigger the workflow and verify the label gets added

🤖 Generated with [Claude Code](https://claude.com/claude-code)