### PR TITLE
ci: add merge_group trigger to support merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  merge_group:
 
 jobs:
   CI:


### PR DESCRIPTION
## Summary
- Adds `merge_group` event trigger to `ci.yml` so CI checks run on merge queue entries
- Required prerequisite before enabling GitHub's merge queue in branch protection settings
- Without this, the merge queue would fail because status checks wouldn't report

## After merging
Enable merge queue in repo settings:
1. Go to Settings → Branches → Edit `main` protection rule
2. Check "Require merge queue"
3. Set merge method to Squash

## Test plan
- [ ] CI still triggers on pull_request events (this PR itself proves it)
- [ ] Workflow lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)