### PR TITLE
ci: auto-update automerge PR branches when main changes

### DIFF
--- a/.github/workflows/auto-update-branches.yml
+++ b/.github/workflows/auto-update-branches.yml
@@ -1,0 +1,45 @@
+name: Auto Update Branches
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  update-branches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update automerge PR branches
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pulls } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              base: 'main',
+              sort: 'created',
+              direction: 'asc',
+            });
+
+            const automerge = pulls.filter(pr =>
+              pr.labels.some(l => l.name === 'automerge')
+            );
+
+            for (const pr of automerge) {
+              try {
+                await github.rest.pulls.updateBranch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                });
+                core.info(`Updated PR #${pr.number}: ${pr.title}`);
+              } catch (err) {
+                core.warning(`Failed to update PR #${pr.number}: ${err.message}`);
+              }
+            }
+
+            core.info(`Updated ${automerge.length} PR(s) with automerge label`);


### PR DESCRIPTION
## Summary
- New workflow triggers on every push to `main` (i.e., when a PR merges)
- Finds all open PRs with the `automerge` label and updates their branches to latest main
- This creates an automated sequential merge chain: merge → update next PR → CI runs → merge → repeat
- Keeps `strict` status checks enabled so we never merge PRs that haven't been tested against current main

## How it works
1. Jules PR gets Claude approval → `automerge` label added (via #108)
2. PR branch is up to date → CI passes → mergery merges it
3. Push to main triggers this workflow → updates remaining automerge PRs
4. Next PR's CI runs on updated branch → passes → merges → cycle continues

## Test plan
- [ ] Workflow lint passes
- [ ] After this merges, the 5 open Jules PRs with `automerge` label should start chaining through

🤖 Generated with [Claude Code](https://claude.com/claude-code)