### PR TITLE
fix: accept accented characters in community roster names

### DIFF
--- a/src/Services/CommunityService.lua
+++ b/src/Services/CommunityService.lua
@@ -16,7 +16,8 @@ function WHLSN:ValidateCommunityName(name)
     local trimmed = strtrim(name)
     if trimmed == "" then return false, "Name cannot be empty" end
     -- Validate format: Name or Name-Realm (realm may contain digits, e.g., Area52)
-    if not trimmed:match("^[%a']+$") and not trimmed:match("^[%a']+%-[%a%d'%-]+$") then
+    -- \128-\255 matches non-ASCII UTF-8 bytes so accented names like Müzaka are accepted
+    if not trimmed:match("^[%a'\128-\255]+$") and not trimmed:match("^[%a'\128-\255]+%-[%a%d'\128-\255%-]+$") then
         return false, "Invalid name format. Use 'Player' or 'Player-Realm'."
     end
     return true

--- a/tests/test_community_service.lua
+++ b/tests/test_community_service.lua
@@ -126,6 +126,16 @@ describe("CommunityService", function()
             assert.is_true(ok)
         end)
 
+        it("should accept names with accented characters", function()
+            local ok = WHLSN:ValidateCommunityName("Müzaka")
+            assert.is_true(ok)
+        end)
+
+        it("should accept accented names with realm", function()
+            local ok = WHLSN:ValidateCommunityName("Müzaka-Illidan")
+            assert.is_true(ok)
+        end)
+
         it("should treat first hyphen as realm separator", function()
             -- "My-Name-Realm" → character "My" on realm "Name-Realm"
             local ok = WHLSN:ValidateCommunityName("My-NameRealm")


### PR DESCRIPTION
## Summary
- `ValidateCommunityName` used `%a` in its Lua pattern, which only matches ASCII letters — rejecting valid WoW character names with accented characters (e.g., Müzaka)
- Extended the character class with `\128-\255` to match non-ASCII UTF-8 bytes alongside ASCII letters
- Added tests for accented names (bare and realm-qualified)

Closes #119

## Test plan
- [x] New tests for accented bare name (`Müzaka`) and realm-qualified (`Müzaka-Illidan`) both pass
- [x] All 316 existing tests still pass
- [x] Luacheck clean (0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)